### PR TITLE
docs: add Unraid trademark disclaimer for policy compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,3 +336,7 @@ Contributions welcome! Please ensure:
 - [Official Unraid API Repository](https://github.com/unraid/api)
 - [GraphQL API Reference](UNRAIDAPI.md)
 - [PyPI Package](https://pypi.org/project/unraid-api/)
+
+## Disclaimer
+
+Unraid® is a registered trademark of Lime Technology, Inc. This project is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.


### PR DESCRIPTION
Adds required attribution statement per Unraid's Third Party App
Naming and Trademark Policy (effective October 1, 2025).

https://claude.ai/code/session_01Fo4yZNiWP8YbFNPivrGrtm