### PR TITLE
fix: implement silent fallback to default HTTPS port when custom HTTP ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-02-07
+
+### Fixed
+
+- Silent fallback to default HTTPS port when HTTP probe fails on user-specified port (fixes #9)
+  - When a non-default `http_port` is specified and the port is unreachable, `UnraidConnectionError` is now raised instead of silently connecting on port 443
+  - Default port (80) behavior is unchanged — HTTPS fallback still works for standard HTTP→HTTPS upgrade
+
 ## [1.4.1] - 2026-02-07
 
 ### Added

--- a/src/unraid_api/_version.py
+++ b/src/unraid_api/_version.py
@@ -1,3 +1,3 @@
 """Version information for unraid-api."""
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -265,6 +265,14 @@ class UnraidClient:
                 return (None, False)
 
         except aiohttp.ClientError as err:
+            # When the user specified a custom (non-default) HTTP port and
+            # that port is unreachable, raise immediately — don't silently
+            # fall back to HTTPS on a different port.  See GitHub issue #9.
+            if self.http_port != DEFAULT_HTTP_PORT:
+                raise UnraidConnectionError(
+                    f"Cannot connect to {clean_host} on port {self.http_port}: {err}"
+                ) from err
+
             _LOGGER.debug("HTTP check failed, will try HTTPS: %s", err)
 
         return (None, True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,7 @@ from unraid_api.models import (
     PhysicalDisk,
     Share,
     UnraidArray,
+    _parse_datetime,
 )
 
 
@@ -48,6 +49,12 @@ class TestDatetimeParsing:
         os_info = InfoOs(uptime=dt)
 
         assert os_info.uptime == dt
+
+    def test_parse_unsupported_type_returns_none(self) -> None:
+        """Test that unsupported types return None."""
+        result = _parse_datetime(12345)
+
+        assert result is None
 
 
 class TestArrayCapacity:


### PR DESCRIPTION
### Fixed

- Silent fallback to default HTTPS port when HTTP probe fails on user-specified port (fixes #9)
  - When a non-default `http_port` is specified and the port is unreachable, `UnraidConnectionError` is now raised instead of silently connecting on port 443
  - Default port (80) behavior is unchanged — HTTPS fallback still works for standard HTTP→HTTPS upgrade