### PR TITLE
Potential fix for code scanning alert no. 23: Clear-text logging of sensitive information

### DIFF
--- a/scripts/unraid-api-client.py
+++ b/scripts/unraid-api-client.py
@@ -1034,7 +1034,7 @@ examples:
     args = parser.parse_args()
 
     host, api_key = load_env()
-    print(f"Host: {_sanitize_host(host)}")
+    print("Host: <configured>")
     print(f"API Key: {'*' * 8}...{'*' * 4} (loaded)")
     print()
 


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/23](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/23)

In general, to fix clear-text logging of sensitive information, you should (1) avoid logging secrets entirely or (2) only log a redacted/masked form that does not expose the full secret or any credential-bearing part. Additionally, if taint analysis is concerned about a piece of data (like `host`) that might sometimes contain embedded credentials, logging that data should either be removed or further sanitized so that all potential sensitive parts are stripped before printing.

For this specific script, the minimal, non-functional-change fix is to adjust the logging of the host so that it never outputs any derived configuration value that could contain credentials. The simplest approach is to replace `print(f"Host: {_sanitize_host(host)}")` with a generic confirmation message like `"Host loaded"` that does not interpolate the host at all. This leaves the rest of the script behavior intact (the `host` value is still used to construct the `UnraidClient` and for SSL tests) while eliminating the tainted sink that CodeQL flags. We do not need to change `load_env`, `_sanitize_host`, or how `api_key` is handled, since the API key is already displayed in masked form.

Concretely: in `scripts/unraid-api-client.py`, around line 1036–1039, replace the host-print statement with a non-sensitive message, and keep the API key masking line unchanged. No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
