### PR TITLE
Potential fix for code scanning alert no. 19: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -188,14 +188,32 @@ class UnraidClient:
 
     @staticmethod
     def _sanitize_url(url: str) -> str:
-        """Remove embedded credentials from URL for safe logging."""
-        parsed = urlparse(url)
-        if parsed.username or parsed.password:
-            netloc = parsed.hostname or ""
-            if parsed.port:
-                netloc += f":{parsed.port}"
-            return parsed._replace(netloc=netloc).geturl()
-        return url
+        """Remove embedded credentials and sensitive components from URL for safe logging."""
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            # If parsing fails, avoid logging the raw value
+            return "<invalid-url>"
+
+        hostname = parsed.hostname or ""
+        port = parsed.port
+        if not hostname:
+            # No usable host component; avoid emitting potentially sensitive data
+            return "<redacted>"
+
+        netloc = hostname
+        if port:
+            netloc += f":{port}"
+
+        # Drop username, password, query parameters and fragment entirely
+        sanitized = parsed._replace(
+            netloc=netloc,
+            path=parsed.path or "",
+            params="",
+            query="",
+            fragment="",
+        )
+        return sanitized.geturl()
 
     async def _discover_redirect_url(self) -> tuple[str | None, bool]:
         """Discover the correct URL and SSL mode for the Unraid server.


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/19](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/19)

General fix: Ensure that any URL derived from user- or environment-controlled input is fully sanitized before being logged, stripping not only embedded credentials (`user:pass@host`) but also any query parameters or fragments that might contain secrets. The debug log should only include non-sensitive components: scheme, host, optional port, and path.

Best single change: Enhance `UnraidClient._sanitize_url` in `src/unraid_api/client.py` (the function actually used at the flagged sink) so that it:
- Parses the URL.
- Removes username/password from `netloc` (already done).
- Drops the query (`?foo=bar`) and fragment (`#xyz`) entirely.
- Reconstructs a URL string only from scheme, sanitized netloc, and path.

No other behavior or call sites need to change; `_make_request` can continue to log `self._sanitize_url(self._resolved_url)`, but the sanitized URL will now never contain credentials, tokens, or other secrets even if they are embedded in the host or query.

Concretely, in `src/unraid_api/client.py`, lines 189–198:

```py
189:     @staticmethod
190:     def _sanitize_url(url: str) -> str:
191:         """Remove embedded credentials from URL for safe logging."""
192:         parsed = urlparse(url)
193:         if parsed.username or parsed.password:
194:             netloc = parsed.hostname or ""
195:             if parsed.port:
196:                 netloc += f":{parsed.port}"
197:             return parsed._replace(netloc=netloc).geturl()
198:         return url
```

should be replaced with an implementation that always:
- Builds a `netloc` with only hostname and port.
- Clears `query` and `fragment`.
- Returns the rebuilt URL. It should also handle malformed URLs defensively by returning a generic placeholder if parsing fails or there is no hostname.

No new imports are necessary; `urlparse` is already imported at the top of this file. `scripts/unraid-api-client.py` already has its own `_sanitize_url` for printing and does not log secrets (it masks the API key explicitly), so no changes are required there for this particular alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
