### PR TITLE
Potential fix for code scanning alert no. 22: Clear-text logging of sensitive information

### DIFF
--- a/scripts/unraid-api-client.py
+++ b/scripts/unraid-api-client.py
@@ -960,7 +960,7 @@ async def run_ssl_tests(host: str, api_key: str) -> int:
 
     print("=" * 60)
     print("SSL/TLS DETECTION LIVE TEST")
-    print(f"Host: {_sanitize_host(host)}, HTTP: {http_port}, HTTPS: {https_port}")
+    print(f"HTTP port: {http_port}, HTTPS port: {https_port}")
     print("=" * 60)
 
     results: list[tuple[str, bool]] = []


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/22](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/22)

In general, to fix clear-text logging of sensitive information, either avoid logging the value entirely, or log only a non-sensitive, derived, or heavily redacted form (e.g., fixed mask, prefix/suffix without the secret, or just structural information like “configured” vs “missing”). For host/URL values that might accidentally contain credentials, the safest approach is to avoid printing the raw or partially sanitized string and instead log just high-level information (e.g., “Host configured”, or only the hostname without any userinfo, query, or path).

For this specific code, the problematic sink is the `print` in `run_ssl_tests`:

```python
print(f"SSL/TLS DETECTION LIVE TEST")
print(f"Host: {_sanitize_host(host)}, HTTP: {http_port}, HTTPS: {https_port}")
```

The simplest, least intrusive fix is to stop printing the potentially tainted host value here. We already print a masked API key earlier in `main()`, and we print a sanitized host there as well; the SSL test does not strictly need to echo the host again, or it can print a non-sensitive placeholder. The most conservative change is to remove the host interpolation in this message while keeping useful non-sensitive data (ports) for diagnostics.

Concretely:

- In `scripts/unraid-api-client.py`, inside `run_ssl_tests`, replace the line that prints host + ports with a line that only prints port information (or a generic statement) without including `host`. For example:
  - From: `print(f"Host: {_sanitize_host(host)}, HTTP: {http_port}, HTTPS: {https_port}")`
  - To:   `print(f"HTTP port: {http_port}, HTTPS port: {https_port}")`
- No new imports or helper functions are required; we simply avoid logging a value that could be tainted.
- This change preserves all functional behavior of the SSL tests (no logic depends on this string) while eliminating the possibility of logging the host (and any credentials that might have been embedded) at this location, which should satisfy all variants of the alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
