### PR TITLE
Potential fix for code scanning alert no. 21: Clear-text logging of sensitive information

### DIFF
--- a/scripts/unraid-api-client.py
+++ b/scripts/unraid-api-client.py
@@ -944,7 +944,6 @@ async def _test_ssl_connection(
             print(f"  Discovery: redirect_url={_sanitize_url(redirect_url)}, use_ssl={use_ssl}")
             client._resolved_url = None
             result = await client.test_connection()
-            print(f"  Resolved URL: {_sanitize_url(client._resolved_url)}")
             print(f"  test_connection: {result}")
             print("  RESULT: PASS")
             return True


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/21](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/21)

General fix approach: prevent any potentially sensitive information derived from credentials (including URLs that may contain embedded credentials or hostnames considered sensitive) from being written to stdout/logs in clear text. In this specific case, we can remove or reduce the granularity of the “Resolved URL” logging in the test script, since it’s not essential for the core functionality, and other prints already show non‑sensitive information (host is sanitized, API key is masked).

Best concrete fix: in `scripts/unraid-api-client.py`, inside `_test_ssl_connection`, simply stop printing `client._resolved_url` (even via `_sanitize_url`). The SSL test will still run, we still print the final test result and redirect discovery info (which is already sanitized), and we eliminate the scanner‑flagged sink. We don’t need to change `UnraidClient` or its internal logging, and we don’t need additional libraries.

Specifically:

- File: `scripts/unraid-api-client.py`
  - In `_test_ssl_connection`, remove the line:
    - `print(f"  Resolved URL: {_sanitize_url(client._resolved_url)}")`
  - No new imports or helper functions are required.

This single change addresses all variants because the only flagged sink is that “Resolved URL” print in this script.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
