### PR TITLE
Potential fix for code scanning alert no. 20: Clear-text logging of sensitive information

### DIFF
--- a/scripts/unraid-api-client.py
+++ b/scripts/unraid-api-client.py
@@ -941,7 +941,7 @@ async def _test_ssl_connection(
             verify_ssl=False,
         ) as client:
             redirect_url, use_ssl = await client._discover_redirect_url()
-            print(f"  Discovery: redirect_url={_sanitize_url(redirect_url)}, use_ssl={use_ssl}")
+            print(f"  Discovery: redirect_found={redirect_url is not None}, use_ssl={use_ssl}")
             client._resolved_url = None
             result = await client.test_connection()
             print(f"  Resolved URL: {_sanitize_url(client._resolved_url)}")


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/20](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/20)

General fix: Avoid logging any value that may include credentials (API keys, passwords, or userinfo in URLs) in clear text. If such values are needed for debugging, either (a) sanitize them with a robust, central helper or (b) log only non-sensitive derivatives (e.g., host, port, whether SSL is used).

Best concrete fix here:

1. In `scripts/unraid-api-client.py`, stop printing the potentially sensitive full `redirect_url` string. Instead:
   - Log only whether a redirect was detected and whether SSL is used, or
   - If a URL is useful, ensure it's sanitized using the canonical sanitizer from `UnraidClient` (which already exists as `_sanitize_url` in `src/unraid_api/client.py`).

2. Since this script is meant as a test client and not a library, the least intrusive change that preserves functionality is to:
   - Change the `print` on line 944 to avoid including the redirect URL in the log. We still keep `use_ssl` and a boolean for whether any redirect URL was returned.
   - Optionally, we can keep the script’s `_sanitize_url` helper unchanged (or remove it if it’s no longer used, but that would be a broader cleanup).

This change is confined to `scripts/unraid-api-client.py` in the `_test_ssl_connection` function. No new imports or helper methods are required: we simply change the format string to avoid including `redirect_url` at all, thus eliminating any possible leak of API key or password while leaving all network behavior unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted SSL detection diagnostic output to display redirect status as a boolean value instead of the redirect URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->