### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -173,18 +173,31 @@ class UnraidClient:
             self._session = None
 
     def _get_clean_host(self) -> str:
-        """Get host without protocol prefix or embedded credentials."""
-        host = self.host
+        """Get a sanitized host string safe for logging (no credentials)."""
+        host = (self.host or "").strip()
+
+        # If this looks like a URL, parse it and extract only hostname[:port]
         if "://" in host:
-            parsed = urlparse(host)
+            try:
+                parsed = urlparse(host)
+            except Exception:
+                # Avoid logging unparsed value that might contain secrets
+                return "<redacted-host>"
+
             hostname = parsed.hostname or ""
+            if not hostname:
+                return "<redacted-host>"
+
             if parsed.port:
                 return f"{hostname}:{parsed.port}"
-            return hostname.rstrip("/")
-        # Strip userinfo (user:pass@) if present
+            return hostname
+
+        # Strip userinfo (user:pass@) if present in non-URL host
         if "@" in host:
             host = host.split("@", 1)[1]
-        return host.rstrip("/")
+
+        host = host.rstrip("/")
+        return host or "<redacted-host>"
 
     @staticmethod
     def _sanitize_url(url: str) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/18](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/18)

In general, to fix clear-text logging of sensitive information you either: (1) stop logging the sensitive value entirely, or (2) log only a redacted/sanitized representation that cannot reveal secrets (for example, log only hostname without credentials, or a fixed placeholder). In this case, we should ensure that any value derived from user-provided `host` that reaches `_LOGGER.warning` is strictly sanitized so that it can never contain embedded credentials or other secrets, regardless of how `host` is formed.

The best fix here is to refactor `_get_clean_host()` so that it behaves as a strict sanitizer: it should always remove any username/password (`user:pass@`) from the host, and when dealing with full URLs it should use `urllib.parse.urlparse` to extract only the hostname and optional port. If parsing fails or yields no hostname, it should return a fixed placeholder such as `"<redacted-host>"` instead of echoing back the raw input. This maintains existing functionality (logging which server has SSL verification disabled) while ensuring no sensitive data is exposed. We then keep the existing call site in `_create_session()` but rely on the stricter sanitizer. No changes are required in `scripts/unraid-api-client.py` for this particular alert, because the console prints there already avoid printing the raw API key and don’t log via `_LOGGER`. All changes stay in `src/unraid_api/client.py`, within the shown snippets, and reuse the existing `urlparse` import; no new dependencies are needed.

Concretely:
- Update `_get_clean_host` in `src/unraid_api/client.py` (around lines 175–187) to:
  - Wrap URL parsing in a `try/except` and never return the unparsed value on failure.
  - When a scheme is present, return only `hostname[:port]` if available, or `"<redacted-host>"` if not.
  - When there is `@` in the host without scheme, always drop the part before `@` and then strip trailing slashes.
  - As a final fallback, return the host with trailing slashes removed, or `"<redacted-host>"` if empty.
- Leave `_create_session`’s `_LOGGER.warning` format string unchanged; now it will always receive a sanitized, non-sensitive host string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
