### PR TITLE
Potential fix for code scanning alert no. 15: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -254,7 +254,7 @@ class UnraidClient:
         )
 
         http_url = f"http://{clean_host}{http_port_suffix}/graphql"
-        _LOGGER.debug("Checking for redirect at %s", http_url)
+        _LOGGER.debug("Checking for redirect at %s", self._sanitize_url(http_url))
 
         try:
             async with self._session.get(


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/15](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/15)

General approach: Never log URLs or hosts that may contain credentials or other sensitive data in clear text. Instead, sanitize any such values before logging so that userinfo and other potentially sensitive components are removed or redacted. The functional behavior (network calls, redirects, etc.) should continue to use the full values; only the log messages should change.

Best concrete fix here: In `src/unraid_api/client.py`, `_discover_redirect_url` currently logs `http_url` directly:

```python
http_url = f"http://{clean_host}{http_port_suffix}/graphql"
_LOGGER.debug("Checking for redirect at %s", http_url)
```

We already have a `_sanitize_url` static method in `UnraidClient` that removes embedded credentials and sensitive components from a URL for safe logging. We should use this helper when logging `http_url`. That way, even if `clean_host` somehow contains credentials or other sensitive fragments, the logged value will be sanitized. Network requests should still use the original `http_url`, so we do not modify the `aiohttp` call.

Concretely:

- In `src/unraid_api/client.py`, within `_discover_redirect_url`, change the debug call to:

  ```python
  _LOGGER.debug("Checking for redirect at %s", self._sanitize_url(http_url))
  ```

No new imports or helpers are needed; `_sanitize_url` already exists in the class. The scripts file (`scripts/unraid-api-client.py`) does not directly log the API key (it explicitly masks it in `main()`), and the CodeQL taint chain is satisfied by fixing the sink in `client.py`, so no changes there are necessary for this alert.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
