### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -173,26 +173,29 @@ class UnraidClient:
             self._session = None
 
     def _get_clean_host(self) -> str:
-        """Get a sanitized host string safe for logging (no credentials)."""
-        host = (self.host or "").strip()
+        """Get a sanitized host string safe for logging (no credentials or secrets)."""
+        raw_host = (self.host or "").strip()
+        if not raw_host:
+            return "<redacted-host>"
 
-        # If this looks like a URL, parse it and extract only hostname[:port]
-        if "://" in host:
-            try:
-                parsed = urlparse(host)
-            except Exception:
-                # Avoid logging unparsed value that might contain secrets
+        # If this looks like a URL, sanitize it first, then extract host[:port]
+        if "://" in raw_host:
+            sanitized = self._sanitize_url(raw_host)
+            if sanitized in ("<invalid-url>", "<redacted>"):
                 return "<redacted-host>"
-
+            try:
+                parsed = urlparse(sanitized)
+            except Exception:
+                return "<redacted-host>"
             hostname = parsed.hostname or ""
             if not hostname:
                 return "<redacted-host>"
-
             if parsed.port:
                 return f"{hostname}:{parsed.port}"
             return hostname
 
-        # Strip userinfo (user:pass@) if present in non-URL host
+        # Non-URL host: strip any userinfo (user:pass@) if present
+        host = raw_host
         if "@" in host:
             host = host.split("@", 1)[1]
 


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/18](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/18)

General approach: Ensure that any value derived from untrusted configuration which may contain credentials or other secrets is thoroughly sanitized before being passed to logging functions. In this context, we should guarantee that `_get_clean_host()` and any related URL/host helpers can never return strings containing usernames, passwords, tokens, or other sensitive components, even if `host` is incorrectly set to a full URL with embedded credentials.

Best concrete fix: In `src/unraid_api/client.py`, rework `_get_clean_host()` to be a thin wrapper around a more robust, general-purpose `_sanitize_url()` helper that already strips credentials and removes query/fragment parts. The goal is to (a) parse any URL-like string, (b) drop userinfo, query, and fragment, and (c) return only hostname[:port] or a safe placeholder if parsing fails or hostname is absent. Additionally, `_sanitize_url()` itself should be defined (or refined if already present) to enforce this behavior generically. This way, `self._get_clean_host()` can be safely used in logging regardless of how `host` is configured, and CodeQL’s path from API key → client → `_get_clean_host()` → log is cut off because the sanitized output can never contain the key.

Specific changes:

- In `src/unraid_api/client.py`, replace the existing `_get_clean_host` method with an implementation that:
  - Treats `self.host` as potentially containing a full URL or an `user:pass@host` pattern.
  - If it looks like a URL (contains `://`), delegates to `_sanitize_url` and then extracts just the netloc (hostname[:port]) from the sanitized URL.
  - If it is not a URL but contains `@`, strips the userinfo portion.
  - Returns `"<redacted-host>"` if parsing fails or no hostname is present, avoiding logging the raw input.

- Also in `src/unraid_api/client.py`, (re)define `_sanitize_url` as a `@staticmethod` that:
  - Uses `urlparse` to parse the URL.
  - Returns `"<invalid-url>"` or `"<redacted>"` when parsing fails or hostname is missing.
  - Constructs a `netloc` from `hostname` and `port` only, discarding any username/password, params, query, and fragment, and returns the resulting URL string.

These updates are all localized to `src/unraid_api/client.py` in the shown snippet. No functional behavior of the client’s network logic changes; only the content of log messages is altered (to remove any possibility of including secrets). `scripts/unraid-api-client.py` does not need code changes to address the logging issue, since it already masks the API key when printing and does not log the raw key; the reported flow is stopped at the client’s sanitized logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host configuration sanitisation and validation to ensure sensitive credentials, user information, and secrets are reliably redacted from logs and system outputs
  * Enhanced handling of various edge cases and error conditions, including empty host values, invalid URL formats, and malformed configurations, to prevent inadvertent exposure of sensitive system information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->