### PR TITLE
Potential fix for code scanning alert no. 26: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -239,6 +239,27 @@ class UnraidClient:
         if host and len(host) >= 24 and all(ch not in host for ch in (".", ":", "/")):
             return "<redacted-host>"
 
+        # Additional safeguards: only log strings that look like a normal host[:port].
+        # - Reject values with whitespace or control characters.
+        # - Reject very long values that are unlikely to be hostnames.
+        # - Reject values where most characters are not typical hostname characters.
+        if any(ch.isspace() for ch in host):
+            return "<redacted-host>"
+
+        if len(host) > 255:
+            # Longer than any reasonable hostname/IP representation.
+            return "<redacted-host>"
+
+        # Keep letters, digits, dot, dash, colon and brackets (for IPv6).
+        safe_chars = set("abcdefghijklmnopqrstuvwxyz"
+                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                         "0123456789"
+                         ".:-[]")
+        safe_count = sum(1 for ch in host if ch in safe_chars)
+        # If fewer than 70% of characters are "host-like", assume it may be a secret.
+        if safe_count == 0 or safe_count / len(host) < 0.7:
+            return "<redacted-host>"
+
         return host or "<redacted-host>"
 
     @staticmethod

--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -134,7 +134,7 @@ class UnraidClient:
     def __repr__(self) -> str:
         """Safe repr that never exposes the API key."""
         return (
-            f"UnraidClient(host={self._get_clean_host()!r}, "
+            f"UnraidClient(host={self._sanitize_host_for_log()!r}, "
             f"port={self.https_port}, verify_ssl={self.verify_ssl})"
         )
 
@@ -168,7 +168,7 @@ class UnraidClient:
             _LOGGER.warning(
                 "SSL verification disabled for %s. "
                 "Connection is encrypted but server identity is not verified.",
-                self._get_clean_host(),
+                self._sanitize_host_for_log(),
             )
         else:
             ssl_context = True
@@ -207,8 +207,12 @@ class UnraidClient:
                 _LOGGER.debug("Error closing session", exc_info=True)
             self._session = None
 
-    def _get_clean_host(self) -> str:
-        """Get a sanitized host string safe for logging (no credentials or secrets)."""
+    def _sanitize_host_for_log(self) -> str:  # noqa: PLR0911
+        """Get a sanitized host string safe for logging (no credentials or secrets).
+
+        This method is ONLY for logging purposes and may return placeholder strings
+        like "<redacted-host>". Never use this for URL construction.
+        """
         raw_host = (self.host or "").strip()
         if not raw_host:
             return "<redacted-host>"
@@ -262,6 +266,65 @@ class UnraidClient:
 
         return host or "<redacted-host>"
 
+    def _normalize_host_for_request(self) -> str:
+        """Normalize and validate the host for actual network requests.
+
+        This method MUST return a valid, routable hostname or IP address.
+        Never returns placeholder strings like "<redacted-host>".
+
+        Returns:
+            str: A valid hostname or IP address suitable for URL construction.
+
+        Raises:
+            UnraidConnectionError: If the host is invalid or cannot be normalized.
+        """
+        raw_host = (self.host or "").strip()
+        if not raw_host:
+            raise UnraidConnectionError("Host cannot be empty")
+
+        # If this looks like a URL, extract the hostname
+        if "://" in raw_host:
+            try:
+                parsed = urlparse(raw_host)
+                hostname = parsed.hostname
+                if not hostname:
+                    raise UnraidConnectionError(
+                        f"Could not extract hostname from URL: {raw_host}"
+                    )
+                # Preserve port from URL if present
+                if parsed.port:
+                    return f"{hostname}:{parsed.port}"
+                return hostname
+            except Exception as e:
+                raise UnraidConnectionError(
+                    f"Invalid host URL format: {raw_host}"
+                ) from e
+
+        # Non-URL host: strip any userinfo (user:pass@) if present
+        host = raw_host
+        if "@" in host:
+            host = host.split("@", 1)[1]
+
+        host = host.rstrip("/")
+
+        # Basic validation: ensure it's not empty after normalization
+        if not host:
+            raise UnraidConnectionError("Host cannot be empty after normalization")
+
+        # Reject hosts with whitespace (likely invalid)
+        if any(ch.isspace() for ch in host):
+            raise UnraidConnectionError(
+                "Host contains whitespace characters, which is invalid"
+            )
+
+        # Reject unreasonably long hostnames
+        if len(host) > 255:
+            raise UnraidConnectionError(
+                "Host exceeds maximum length of 255 characters"
+            )
+
+        return host
+
     @staticmethod
     def _sanitize_url(url: str) -> str:
         """Remove credentials and sensitive components from URL for logging."""
@@ -313,7 +376,8 @@ class UnraidClient:
         if self._session is None:
             raise UnraidConnectionError("Failed to create HTTP session")
 
-        clean_host = self._get_clean_host()
+        # Get validated host for URL construction
+        request_host = self._normalize_host_for_request()
 
         # Short-circuit: if http_port == https_port, assume this port is configured
         # to serve HTTPS and skip the plain HTTP probe to avoid a likely 400 from nginx.
@@ -321,7 +385,7 @@ class UnraidClient:
             _LOGGER.debug(
                 "http_port == https_port (%d), assuming HTTPS for %s",
                 self.http_port,
-                clean_host,
+                self._sanitize_host_for_log(),
             )
             return (None, True)
 
@@ -329,8 +393,11 @@ class UnraidClient:
             "" if self.http_port == DEFAULT_HTTP_PORT else f":{self.http_port}"
         )
 
-        http_url = f"http://{clean_host}{http_port_suffix}/graphql"
+        http_url = f"http://{request_host}{http_port_suffix}/graphql"
         _LOGGER.debug("Checking for redirect at %s", self._sanitize_url(http_url))
+
+        # Get sanitized host for logging
+        clean_host = self._sanitize_host_for_log()
 
         try:
             async with self._session.get(http_url, allow_redirects=False) as response:
@@ -455,7 +522,7 @@ class UnraidClient:
             if redirect_url:
                 self._resolved_url = redirect_url
             else:
-                clean_host = self._get_clean_host()
+                request_host = self._normalize_host_for_request()
                 if use_ssl:
                     protocol = "https"
                     port_suffix = (
@@ -470,7 +537,7 @@ class UnraidClient:
                         if self.http_port != DEFAULT_HTTP_PORT
                         else ""
                     )
-                self._resolved_url = f"{protocol}://{clean_host}{port_suffix}/graphql"
+                self._resolved_url = f"{protocol}://{request_host}{port_suffix}/graphql"
             _LOGGER.debug("Using URL: %s", self._sanitize_url(self._resolved_url))
 
         url = self._resolved_url
@@ -651,7 +718,7 @@ class UnraidClient:
             if redirect_url:
                 self._resolved_url = redirect_url
             else:
-                clean_host = self._get_clean_host()
+                request_host = self._normalize_host_for_request()
                 if use_ssl:
                     protocol = "https"
                     port_suffix = (
@@ -666,7 +733,7 @@ class UnraidClient:
                         if self.http_port != DEFAULT_HTTP_PORT
                         else ""
                     )
-                self._resolved_url = f"{protocol}://{clean_host}{port_suffix}/graphql"
+                self._resolved_url = f"{protocol}://{request_host}{port_suffix}/graphql"
 
     async def _ws_connect_and_init(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,34 +104,34 @@ class TestClientHostParsing:
     """Tests for host parsing functionality."""
 
     def test_get_clean_host_without_protocol(self, api_key: str) -> None:
-        """Test _get_clean_host without protocol prefix."""
+        """Test _normalize_host_for_request without protocol prefix."""
         client = UnraidClient("192.168.1.100", api_key)
 
-        assert client._get_clean_host() == "192.168.1.100"
+        assert client._normalize_host_for_request() == "192.168.1.100"
 
     def test_get_clean_host_with_http(self, api_key: str) -> None:
-        """Test _get_clean_host with http:// prefix."""
+        """Test _normalize_host_for_request with http:// prefix."""
         client = UnraidClient("http://192.168.1.100", api_key)
 
-        assert client._get_clean_host() == "192.168.1.100"
+        assert client._normalize_host_for_request() == "192.168.1.100"
 
     def test_get_clean_host_with_https(self, api_key: str) -> None:
-        """Test _get_clean_host with https:// prefix."""
+        """Test _normalize_host_for_request with https:// prefix."""
         client = UnraidClient("https://192.168.1.100", api_key)
 
-        assert client._get_clean_host() == "192.168.1.100"
+        assert client._normalize_host_for_request() == "192.168.1.100"
 
     def test_get_clean_host_strips_trailing_slash(self, api_key: str) -> None:
-        """Test _get_clean_host strips trailing slashes."""
+        """Test _normalize_host_for_request strips trailing slashes."""
         client = UnraidClient("192.168.1.100/", api_key)
 
-        assert client._get_clean_host() == "192.168.1.100"
+        assert client._normalize_host_for_request() == "192.168.1.100"
 
     def test_get_clean_host_with_full_url(self, api_key: str) -> None:
-        """Test _get_clean_host with full URL including path."""
+        """Test _normalize_host_for_request with full URL including path."""
         client = UnraidClient("https://myserver.myunraid.net/", api_key)
 
-        assert client._get_clean_host() == "myserver.myunraid.net"
+        assert client._normalize_host_for_request() == "myserver.myunraid.net"
 
 
 class TestClientSessionProperty:


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/26](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/26)

General approach: Ensure that any value derived from potentially sensitive inputs (environment variables, `.env` file entries) is never logged in clear text. Specifically, `_get_clean_host()` must guarantee that it cannot return a string containing credentials or token-like data, even if the caller passes a malformed or secret-bearing host. Since the warning is triggered by `_LOGGER.warning(..., self._get_clean_host())`, tightening `_get_clean_host()` is sufficient to fix all alert variants.

Best concrete fix in this code: Adjust `_get_clean_host()` in `src/unraid_api/client.py` to be strictly non‑leaky:

1. For URL-like hosts, continue to use `_sanitize_url()`, but treat more cases as “redacted” if parsing fails or there is no safe hostname.
2. After deriving the `host` string, add stronger heuristics to detect secrets:
   - Redact if the string contains characters typical of tokens (e.g., many consecutive base64-ish chars, or a high ratio of non‑host characters).
   - Redact if it contains spaces, control characters, or looks nothing like a hostname/IP.
   - Redact if it is very long, or if removing common host characters leaves a long residual segment (strong indicator of a token).
3. Return placeholders like `<redacted-host>` unless the value clearly looks like a normal hostname/IP with optional port.

This change is entirely localized to `src/unraid_api/client.py` and does not alter public behavior of the client beyond making the warning log message less specific in edge cases. The scripts (`scripts/unraid-api-client.py`, `scripts/validate-schema.py`) do not need modifications: they never log the raw API key and already mask it when printing; and CodeQL’s dataflow concern is satisfied once `_get_clean_host()` cannot emit secrets derived from misused input.

Concretely:

- Edit `src/unraid_api/client.py` in the `_get_clean_host` method (lines ~210–242) to:
  - Keep the URL parsing and userinfo stripping logic.
  - Add stronger “looks like a secret” detection (length and character checks).
  - Fall back to `<redacted-host>` when in doubt.

No new imports or external dependencies are needed; we rely only on `len`, `str.isalnum`, etc., which are already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host validation and URL construction for connections, reducing failures with malformed or unusually long host values.
  * Enhanced logging redaction to better protect sensitive or malformed host data.
  * More reliable error reporting when a configured host is invalid, helping diagnose connection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->