### PR TITLE
Potential fix for code scanning alert no. 28: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -385,7 +385,7 @@ class UnraidClient:
             _LOGGER.debug(
                 "http_port == https_port (%d), assuming HTTPS for %s",
                 self.http_port,
-                self._sanitize_host_for_log(),
+                "<configured-host>",
             )
             return (None, True)
 


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/28](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/28)

General fix: avoid logging any value that may originate from sensitive or user-controlled credential-bearing inputs, even if sanitized heuristically. Log only static/safe metadata (for example, port numbers or a constant placeholder), or derive values from a strict allowlist transformation.

Best minimal fix here (without changing functionality): in `src/unraid_api/client.py`, inside `_discover_redirect_url()` when `http_port == https_port`, replace the `%s` host argument with a constant placeholder string. This keeps the debug message and control flow unchanged while guaranteeing no sensitive data can ever be emitted and eliminating all alert variants that converge on this sink.

Change needed:
- File: `src/unraid_api/client.py`
- Region: `_discover_redirect_url()` debug log block around current lines 385–389.
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
