### PR TITLE
Potential fix for code scanning alert no. 27: Clear-text logging of sensitive information

### DIFF
--- a/src/unraid_api/client.py
+++ b/src/unraid_api/client.py
@@ -166,9 +166,8 @@ class UnraidClient:
         if not self.verify_ssl:
             ssl_context = False
             _LOGGER.warning(
-                "SSL verification disabled for %s. "
+                "SSL verification disabled. "
                 "Connection is encrypted but server identity is not verified.",
-                self._sanitize_host_for_log(),
             )
         else:
             ssl_context = True


### PR DESCRIPTION
Potential fix for [https://github.com/ruaan-deysel/unraid-api/security/code-scanning/27](https://github.com/ruaan-deysel/unraid-api/security/code-scanning/27)

General fix: remove sensitive/tainted dynamic content from log messages in security warnings, or replace with constant/redacted placeholders. This preserves behavior while eliminating the possibility of credential leakage via logs.

Best single fix here: in `src/unraid_api/client.py`, update the `_LOGGER.warning` call in `_create_session()` to no longer interpolate `self._sanitize_host_for_log()` (or any user-controlled host string). Keep the warning semantics unchanged (SSL verification is disabled) but make the log message constant. This addresses all listed variants because they converge on the same sink line.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
